### PR TITLE
fix: quality drop on long images using webtoon read mode

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/eren76/mangly/composables/screens/readviewer/ReaderPageLoader.kt
+++ b/composeApp/src/androidMain/kotlin/com/eren76/mangly/composables/screens/readviewer/ReaderPageLoader.kt
@@ -10,6 +10,7 @@ import coil3.request.ErrorResult
 import coil3.request.ImageRequest
 import coil3.request.ImageResult
 import coil3.request.SuccessResult
+import coil3.request.allowHardware
 import coil3.request.bitmapConfig
 import coil3.request.crossfade
 import coil3.size.Size
@@ -45,22 +46,31 @@ suspend fun loadReaderPagesIncrementally(
                         .memoryCachePolicy(CachePolicy.ENABLED)
                         .diskCachePolicy(CachePolicy.ENABLED)
                         .bitmapConfig(Bitmap.Config.ARGB_8888)
+                        .allowHardware(false)
                         .size(Size.ORIGINAL)
                         .build()
 
                     val result: ImageResult = withContext(Dispatchers.IO) {
                         imageLoader.execute(request)
                     }
+
                     when (result) {
                         is SuccessResult -> {
-                            val bitmap = result.image.toBitmap()
-                            val bytes = withContext(Dispatchers.IO) {
+                            val rawBytes: ByteArray? = withContext(Dispatchers.IO) {
+                                result.diskCacheKey?.let { key ->
+                                    imageLoader.diskCache?.openSnapshot(key)?.use { snapshot ->
+                                        runCatching {
+                                            snapshot.data.toFile().readBytes()
+                                        }.getOrNull()
+                                    }
+                                }
+                            }
+
+                            // fallback to decoding the bitmap and re-encoding it if we can't get the raw bytes from the disk cache
+                            val bytes = rawBytes ?: withContext(Dispatchers.IO) {
+                                val bitmap = result.image.toBitmap()
                                 ByteArrayOutputStream().use { baos ->
-                                    bitmap.compress(
-                                        Bitmap.CompressFormat.PNG,
-                                        100,
-                                        baos
-                                    )
+                                    bitmap.compress(Bitmap.CompressFormat.PNG, 100, baos)
                                     baos.toByteArray()
                                 }
                             }
@@ -80,6 +90,3 @@ suspend fun loadReaderPagesIncrementally(
         }
     }.awaitAll()
 }
-
-
-

--- a/composeApp/src/androidMain/kotlin/com/eren76/mangly/composables/screens/readviewer/webtoon/WebtoonImage.kt
+++ b/composeApp/src/androidMain/kotlin/com/eren76/mangly/composables/screens/readviewer/webtoon/WebtoonImage.kt
@@ -27,10 +27,7 @@ import com.eren76.mangly.composables.shared.image.ImageLoadingErrorComposable
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-/**
- * We split anything taller than MAX_TEXTURE_SIZE into tiles that each stay within this budget.
- */
-private const val MAX_TEXTURE_SIZE = 2048
+private const val MAX_TEXTURE_SIZE = 4096
 
 object ImageHeightCache {
     private val heightCache = HashMap<String, Dp>()
@@ -57,7 +54,6 @@ fun WebtoonImage(
     val density = LocalDensity.current
     val cachedHeight = remember(page.url) { ImageHeightCache.getHeight(page.url) }
 
-
     val tiles: List<ImageBitmap>? by produceState<List<ImageBitmap>?>(
         initialValue = null,
         key1 = page.state,
@@ -65,20 +61,32 @@ fun WebtoonImage(
         value = when (val state = page.state) {
             is ReaderPageState.Success -> withContext(Dispatchers.Default) {
                 runCatching {
+
+                    val opts = BitmapFactory.Options().apply {
+                        inPreferredConfig = Bitmap.Config.ARGB_8888
+                        inScaled = false
+                    }
+
                     val src: Bitmap =
-                        BitmapFactory.decodeByteArray(state.bytes, 0, state.bytes.size)
+                        BitmapFactory.decodeByteArray(state.bytes, 0, state.bytes.size, opts)
                             ?: return@runCatching null
 
-                    if (src.height <= MAX_TEXTURE_SIZE) {
+                    if (src.height <= MAX_TEXTURE_SIZE && src.width <= MAX_TEXTURE_SIZE) {
                         listOf(src.asImageBitmap())
                     } else {
                         buildList {
                             var y = 0
                             while (y < src.height) {
-                                val tileHeight = minOf(MAX_TEXTURE_SIZE, src.height - y)
-                                val tile = Bitmap.createBitmap(src, 0, y, src.width, tileHeight)
-                                add(tile.asImageBitmap())
-                                y += tileHeight
+                                val tileH = minOf(MAX_TEXTURE_SIZE, src.height - y)
+                                var x = 0
+                                while (x < src.width) {
+                                    val tileW = minOf(MAX_TEXTURE_SIZE, src.width - x)
+                                    val tile =
+                                        Bitmap.createBitmap(src, x, y, tileW, tileH)
+                                    add(tile.asImageBitmap())
+                                    x += tileW
+                                }
+                                y += tileH
                             }
                             src.recycle()
                         }


### PR DESCRIPTION
Fix the quality drop when reading images that are long in height